### PR TITLE
Improve chunking script

### DIFF
--- a/config/repositories.yml
+++ b/config/repositories.yml
@@ -1,28 +1,43 @@
 repositories:
-  - filename: speziaccount.md
+  - title: Spezi Account
     url: https://github.com/stanfordspezi/speziaccount
-    title: Spezi Account Module
-  - filename: spezifirebase.md
+    filename: speziaccount.md
+  - title: Spezi Chat
+    url: https://github.com/stanfordspezi/spezichat
+    filename: spezichat.md
+  - title: Spezi Contact
+    url: https://github.com/stanfordspezi/spezicontact
+    filename: spezicontact.md
+  - title: Spezi Firebase
     url: https://github.com/stanfordspezi/spezifirebase
-    title: Spezi Firebase Integration
-  - filename: spezionboarding.md
+    filename: spezifirebase.md
+  - title: Spezi Onboarding
     url: https://github.com/stanfordspezi/spezionboarding
-    title: Spezi Onboarding Module
-  - filename: spezischeduler.md
+    filename: spezionboarding.md
+  - title: Spezi Scheduler
     url: https://github.com/stanfordspezi/spezischeduler
-    title: Spezi Scheduler Module
-  - filename: spezistorage.md
+    filename: spezischeduler.md
+  - title: Spezi Storage
     url: https://github.com/stanfordspezi/spezistorage
-    title: Spezi Storage Module
-  - filename: speziviews.md
+    filename: spezistorage.md
+  - title: Spezi Views
     url: https://github.com/stanfordspezi/speziviews
-    title: Spezi Views Module
-  - filename: spezillm.md
+    filename: speziviews.md
+  - title: Spezi Access Guard
+    url: https://github.com/stanfordspezi/speziaccessguard
+    filename: speziaccessguard.md
+  - title: Spezi Notifications
+    url: https://github.com/stanfordspezi/spezinotifications
+    filename: spezinotifications.md
+  - title: Spezi LLM
     url: https://github.com/stanfordspezi/spezillm
-    title: Spezi LLM Module
-  - filename: spezihealthkit.md
+    filename: spezillm.md
+  - title: Spezi HealthKit
     url: https://github.com/stanfordspezi/spezihealthkit
-    title: Spezi HealthKit Module
-  - filename: spezitemplateapplication.md
+    filename: spezihealthkit.md
+  - title: Spezi Medication
+    url: https://github.com/stanfordspezi/spezimedication
+    filename: spezimedication.md
+  - title: Spezi Template Application
     url: https://github.com/stanfordspezi/spezitemplateapplication
-    title: Spezi Template Application 
+    filename: spezitemplateapplication.md 

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -32,13 +32,41 @@ Do not update document right after creating it. Wait for user feedback or reques
 `;
 
 export const regularPrompt = `
-  You are a friendly code assistant that helps users with their questions about the Stanford Spezi framework. 
-  
-  When responding:
-  1. For questions about specific topics, first search the knowledge base
-  2. Use the retrieved information to provide accurate answers
-  3. If no relevant information is found, rely on your general knowledge or indicate when you're unsure, but inform the user that you are unsure.
-  4. You can only show code examples in the Swift programming language. Do not offer to generate code in any other language or help with any other language.
+  You are Spezi AI Assistant, a specialized AI helper dedicated to the Stanford Spezi framework for iOS health applications. Your primary purpose is to help developers learn, build, and troubleshoot Spezi-based applications.
+
+  About Spezi:
+  - Spezi is a Swift-based open-source framework created by Stanford University for building digital health applications
+  - It uses a modular approach with various components like SpeziAccount, SpeziHealthKit, SpeziScheduler, SpeziQuestionnaire, etc.
+  - Spezi applications are built using SwiftUI for the interface layer
+  - The framework follows Apple's privacy and security best practices
+
+  When helping users:
+  1. First search the knowledge base for relevant documentation, code examples, and implementation patterns from the Spezi repositories
+  2. Prioritize official Spezi patterns and recommendations over generic Swift solutions
+  3. Provide clear, well-structured explanations that help users understand not just "how" but "why"
+  4. Include code examples when relevant, always in Swift, following the Spezi architectural patterns
+  5. If code seems incorrect or problematic, explain potential issues and suggest improvements
+  6. For complex questions, break down your answer into steps or components
+
+  If you cannot find specific information in the knowledge base:
+  1. Be transparent about what you don't know about Spezi specifically
+  2. Provide general Swift/SwiftUI guidance that aligns with Spezi's architectural principles
+  3. Suggest how the user might find official documentation or examples on the Spezi GitHub repository at https://github.com/StanfordSpezi or the Spezi website at https://spezi.stanford.edu/
+
+  Educational approach:
+  1. For beginners, explain Spezi concepts and terminology
+  2. For more advanced users, focus on implementation details and best practices
+  3. When appropriate, explain how Spezi modules interact with each other
+  4. Highlight module dependencies and typical integration patterns
+
+  Problem-solving guidelines:
+  1. Ask clarifying questions when the user's issue is ambiguous
+  2. Help users debug by suggesting common error causes and troubleshooting steps
+  3. When offering solutions, explain the reasoning so users learn for future problems
+  4. For complex issues, suggest how to break the problem into manageable parts
+
+  Always stay focused on Swift and iOS development context - do not provide help for other platforms or programming languages. 
+  Your goal is to help users become proficient with the Spezi framework.
 `;
 
 export const systemPrompt = ({

--- a/scripts/chunk.ts
+++ b/scripts/chunk.ts
@@ -1,4 +1,4 @@
-import { RecursiveCharacterTextSplitter } from 'langchain/text_splitter';
+import { RecursiveCharacterTextSplitter, MarkdownTextSplitter } from 'langchain/text_splitter';
 import { Document } from 'langchain/document';
 
 /**
@@ -323,29 +323,28 @@ async function chunkMarkdownFile(
   fileHeader: string,
   metadata: Record<string, any>
 ): Promise<Document[]> {
-  // LangChain already provides a markdown-specific splitter
-  const markdownSplitter = new RecursiveCharacterTextSplitter({
+  console.log('\nProcessing Markdown file...');
+  console.log(`Content length: ${content.length}`);
+  
+  // Use LangChain's dedicated markdown splitter
+  const markdownSplitter = new MarkdownTextSplitter({
     chunkSize: 1500,
     chunkOverlap: 200,
-    separators: [
-      // Headers
-      "\n## ", "\n### ", "\n#### ", "\n##### ", "\n###### ",
-      // Block level elements
-      "\n\n", "\n```", "\n---", "\n___", "\n***",
-      // Fallbacks
-      "\n", " ", ""
-    ],
-    keepSeparator: true,
   });
   
-  const fileContent = fileHeader ? content.substring(fileHeader.length) : content;
-  const chunks = await markdownSplitter.createDocuments([fileContent]);
+  console.log('Splitting markdown content...');
+  const chunks = await markdownSplitter.createDocuments([content]);
+  
+  console.log(`Generated ${chunks.length} chunks`);
   
   // Add file header to each chunk
-  return chunks.map(chunk => new Document({
-    pageContent: `${fileHeader}${chunk.pageContent}`,
-    metadata
-  }));
+  return chunks.map(chunk => {
+    console.log(`Processing chunk of length: ${chunk.pageContent.length}`);
+    return new Document({
+      pageContent: `${fileHeader}${chunk.pageContent}`,
+      metadata
+    });
+  });
 }
 
 /**

--- a/scripts/chunk.ts
+++ b/scripts/chunk.ts
@@ -83,17 +83,17 @@ async function splitIntoFileDocuments(content: string): Promise<Document[]> {
     const fileRegex = /^={2,}\nFile: (.+?)\n={2,}\n/gm;
     const documents: Document[] = [];
     
-    let match;
+    let match: RegExpExecArray | null = null;
     let lastIndex = 0;
     let fileCount = 0;
     
     console.log('Searching for file markers...');
-    
-    while ((match = fileRegex.exec(content)) !== null) {
+    match = fileRegex.exec(content);
+    while (match !== null) {
         fileCount++;
         const filename = match[1];
         const startIndex = match.index;
-        const headerLength = match[0].length;  // Get the full length of the header
+        const headerLength = match[0].length;
         
         console.log(`\nFound file ${fileCount}: ${filename}`);
         console.log(`File marker at index: ${startIndex}`);
@@ -104,7 +104,7 @@ async function splitIntoFileDocuments(content: string): Promise<Document[]> {
             const fileContent = content.substring(lastIndex, startIndex);
             console.log(`Extracting content of length: ${fileContent.length}`);
             
-            if (fileContent.trim().length > 0) {  // Only add if there's actual content
+            if (fileContent.trim().length > 0) {
                 documents.push(new Document({
                     pageContent: fileContent,
                     metadata: { 
@@ -118,8 +118,11 @@ async function splitIntoFileDocuments(content: string): Promise<Document[]> {
             }
         }
         
-        lastIndex = startIndex + headerLength;  // Advance past the header
+        lastIndex = startIndex + headerLength;
         console.log(`New lastIndex: ${lastIndex}`);
+        
+        // Get next match
+        match = fileRegex.exec(content);
     }
     
     // Add the last file
@@ -132,7 +135,7 @@ async function splitIntoFileDocuments(content: string): Promise<Document[]> {
         const filenameMatch = fileContent.match(/^={2,}\nFile: (.+?)\n={2,}\n/);
         const filename = filenameMatch ? filenameMatch[1] : "unknown";
         
-        if (fileContent.trim().length > 0) {  // Only add if there's actual content
+        if (fileContent.trim().length > 0) {
             documents.push(new Document({
                 pageContent: fileContent,
                 metadata: { 

--- a/scripts/chunk.ts
+++ b/scripts/chunk.ts
@@ -1,0 +1,406 @@
+export const generateChunks = async (input: string): Promise<string[]> => {
+    console.log('Starting chunk generation...');
+    console.log(`Input length: ${input.length} characters`);
+
+    // Split the input into sections based on file boundaries
+    const fileRegex = /^={2,}\nFile: (.+?)\n={2,}\n/gm;
+    const fileSections = [];
+    let lastMatch = null;
+  
+    // First extract the directory structure if present
+    let directoryStructure = "";
+    const dirStructureRegex = /^={2,}\nDirectory Structure\n={2,}\n([\s\S]+?)(?=\n={2,}\n|$)/;
+    const dirMatch = input.match(dirStructureRegex);
+    if (dirMatch) {
+      console.log('Found directory structure section');
+      directoryStructure = dirMatch[0];
+      // We'll keep the directory structure as its own chunk for context
+      fileSections.push(directoryStructure);
+    }
+  
+    // Extract file sections, preserving the file headers
+    console.log('Extracting file sections...');
+    let match;
+    let fileCount = 0;
+    while ((match = fileRegex.exec(input)) !== null) {
+      fileCount++;
+      const start = match.index;
+      const filePath = match[1];
+      console.log(`Found file section: ${filePath}`);
+      
+      // If this isn't the first match, calculate the end of the previous section
+      if (lastMatch) {
+        const end = start;
+        const fileContent = input.substring(lastMatch.index, end);
+        fileSections.push(fileContent);
+      }
+      
+      lastMatch = match;
+    }
+    console.log(`Found ${fileCount} file sections`);
+    
+    // Add the last file section (from the last match to the end)
+    if (lastMatch) {
+      fileSections.push(input.substring(lastMatch.index));
+    } else if (fileSections.length === 0) {
+      console.log('No file sections found, processing entire input as one section');
+      fileSections.push(input);
+    }
+  
+    // Process each file section
+    console.log('Processing file sections into final chunks...');
+    const finalChunks: string[] = [];
+    for (const section of fileSections) {
+      if (section.length <= 1500) {
+        console.log(`Small section (${section.length} chars) kept as single chunk`);
+        finalChunks.push(section);
+        continue;
+      }
+  
+      console.log(`Large section (${section.length} chars) being split...`);
+      const chunks = splitFileContent(section);
+      console.log(`Split into ${chunks.length} chunks`);
+      finalChunks.push(...chunks);
+    }
+  
+    const filteredChunks = finalChunks.filter(chunk => chunk.trim().length > 10);
+    console.log(`Final chunk count: ${filteredChunks.length}`);
+    return filteredChunks;
+  };
+  
+  /**
+   * Split a file content into logical chunks, preserving code structure
+   */
+  const splitFileContent = (fileContent: string): string[] => {
+    console.log('\nSplitting file content...');
+    
+    // Extract the file header for inclusion in each chunk
+    const headerMatch = fileContent.match(/^={2,}\nFile: (.+?)\n={2,}\n/);
+    const fileHeader = headerMatch ? headerMatch[0] : "";
+    const filePath = headerMatch ? headerMatch[1] : "";
+    
+    if (filePath) {
+        console.log(`Processing file: ${filePath}`);
+    }
+    
+    // Remove the header from the content for processing
+    let content = headerMatch 
+      ? fileContent.substring(headerMatch[0].length) 
+      : fileContent;
+    
+    const chunks: string[] = [];
+    
+    // Handle each file type according to its extension
+    if (filePath.endsWith('.swift')) {
+      console.log('Processing as Swift file');
+      chunks.push(...splitSwiftCode(fileHeader, content));
+    } else if (filePath.endsWith('.yml') || filePath.endsWith('.yaml')) {
+      console.log('Processing as YAML file');
+      chunks.push(...splitYamlFile(fileHeader, content));
+    } else if (filePath.endsWith('.md') || filePath.endsWith('.markdown')) {
+      console.log('Processing as Markdown file');
+      chunks.push(...splitMarkdownFile(fileHeader, content));
+    } else if (filePath.endsWith('.json') || filePath.endsWith('.plist')) {
+      console.log('Processing as config file');
+      chunks.push(...splitConfigFile(fileHeader, content));
+    } else {
+      console.log('Processing with default chunking');
+      chunks.push(...splitBySize(fileHeader, content));
+    }
+    
+    console.log(`Generated ${chunks.length} chunks for ${filePath || 'content'}`);
+    return chunks;
+  };
+  
+  /**
+   * Split Swift code by declarations (struct, class, extension, function, etc.)
+   */
+  const splitSwiftCode = (fileHeader: string, content: string): string[] => {
+    console.log('\nProcessing Swift code...');
+    const chunks: string[] = [];
+    let currentChunk = "";
+    
+    // Capture imports and header comments first
+    const headerEndRegex = /^(?:\/\/|import\s+|@_)/gm;
+    let lastHeaderMatch = null;
+    let match;
+    
+    while ((match = headerEndRegex.exec(content)) !== null) {
+        lastHeaderMatch = match;
+    }
+    
+    let headerEnd = 0;
+    if (lastHeaderMatch) {
+        headerEnd = content.indexOf('\n', lastHeaderMatch.index);
+        if (headerEnd === -1) headerEnd = content.length;
+        else headerEnd += 1;
+        
+        const headerSection = content.substring(0, headerEnd).trim();
+        if (headerSection.length > 0) {
+            console.log('Adding header section');
+            chunks.push(`${fileHeader}// File header\n${headerSection}`);
+        }
+    }
+    
+    // Process declarations
+    const swiftDeclRegex = /^(?:public\s+|private\s+|fileprivate\s+|internal\s+|open\s+)?(?:struct|class|enum|protocol|extension|func|var|let)\s+\w+/gm;
+    let lastIndex = headerEnd;
+    
+    while ((match = swiftDeclRegex.exec(content)) !== null) {
+        console.log(`Found Swift declaration at index ${match.index}`);
+        const start = match.index;
+        
+        if (start > lastIndex) {
+            const interstitial = content.substring(lastIndex, start).trim();
+            if (interstitial.length > 0) {
+                if (currentChunk.length + interstitial.length > 1500 && currentChunk.length > 0) {
+                    chunks.push(`${fileHeader}${currentChunk}`);
+                    currentChunk = interstitial + "\n";
+                } else {
+                    currentChunk += (currentChunk ? "\n" : "") + interstitial + "\n";
+                }
+            }
+        }
+        
+        // Find the next declaration to determine the end of this one
+        const nextRegex = new RegExp(swiftDeclRegex);
+        nextRegex.lastIndex = swiftDeclRegex.lastIndex;
+        const nextMatch = nextRegex.exec(content);
+        const end = nextMatch ? nextMatch.index : content.length;
+        
+        const declaration = content.substring(start, end).trim();
+        console.log(`Processing declaration of length ${declaration.length}`);
+        
+        if (currentChunk.length + declaration.length > 1500 && currentChunk.length > 0) {
+            chunks.push(`${fileHeader}${currentChunk}`);
+            currentChunk = declaration;
+        } else {
+            currentChunk += (currentChunk ? "\n" : "") + declaration;
+        }
+        
+        lastIndex = end;
+    }
+    
+    if (currentChunk.length > 0) {
+        chunks.push(`${fileHeader}${currentChunk}`);
+    }
+    
+    console.log(`Swift processing complete. Generated ${chunks.length} chunks`);
+    return chunks;
+  };
+  
+  /**
+   * Split YAML files while preserving section structure
+   */
+  const splitYamlFile = (fileHeader: string, content: string): string[] => {
+    console.log('\nProcessing YAML file...');
+    
+    if (content.length <= 1500) {
+        console.log('Content small enough for single chunk');
+        return [`${fileHeader}${content}`];
+    }
+    
+    const chunks: string[] = [];
+    let currentChunk = "";
+    const lines = content.split('\n');
+    let currentIndent = 0;
+    
+    console.log(`Processing ${lines.length} lines`);
+    
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const indent = line.search(/\S/);
+        
+        // New top-level section
+        if (indent === 0 && line.trim().length > 0) {
+            console.log(`Found top-level section: ${line.trim()}`);
+            
+            if (currentChunk.length > 0) {
+                chunks.push(`${fileHeader}${currentChunk}`);
+                currentChunk = "";
+            }
+            currentIndent = 0;
+        }
+        
+        if (currentChunk.length + line.length + 1 > 1500 && currentChunk.length > 0) {
+            console.log('Creating new chunk due to size limit');
+            chunks.push(`${fileHeader}${currentChunk}`);
+            currentChunk = line;
+        } else {
+            currentChunk += (currentChunk ? "\n" : "") + line;
+        }
+    }
+    
+    if (currentChunk.length > 0) {
+        chunks.push(`${fileHeader}${currentChunk}`);
+    }
+    
+    console.log(`YAML processing complete. Generated ${chunks.length} chunks`);
+    return chunks;
+  };
+  
+  /**
+   * Split Markdown files by headers
+   */
+  const splitMarkdownFile = (fileHeader: string, content: string): string[] => {
+    console.log('\nProcessing Markdown file...');
+    
+    if (content.length <= 1500) {
+        console.log('Content small enough for single chunk');
+        return [`${fileHeader}${content}`];
+    }
+    
+    const chunks: string[] = [];
+    let currentChunk = "";
+    const lines = content.split('\n');
+    
+    console.log(`Processing ${lines.length} lines`);
+    
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        
+        // New section if we find a header
+        if (line.startsWith('#')) {
+            console.log(`Found header: ${line.trim()}`);
+            
+            if (currentChunk.length > 0) {
+                chunks.push(`${fileHeader}${currentChunk}`);
+                currentChunk = "";
+            }
+        }
+        
+        if (currentChunk.length + line.length + 1 > 1500 && currentChunk.length > 0) {
+            console.log('Creating new chunk due to size limit');
+            chunks.push(`${fileHeader}${currentChunk}`);
+            currentChunk = line;
+        } else {
+            currentChunk += (currentChunk ? "\n" : "") + line;
+        }
+    }
+    
+    if (currentChunk.length > 0) {
+        chunks.push(`${fileHeader}${currentChunk}`);
+    }
+    
+    console.log(`Markdown processing complete. Generated ${chunks.length} chunks`);
+    return chunks;
+  };
+  
+  /**
+   * Split configuration files like JSON and plist
+   */
+  const splitConfigFile = (fileHeader: string, content: string): string[] => {
+    console.log('\nProcessing config file...');
+    
+    if (content.length <= 1500) {
+        console.log('Content small enough for single chunk');
+        return [`${fileHeader}${content}`];
+    }
+    
+    const chunks: string[] = [];
+    let currentChunk = "";
+    const lines = content.split('\n');
+    
+    console.log(`Processing ${lines.length} lines`);
+    
+    for (const line of lines) {
+        if (currentChunk.length + line.length + 1 > 1500 && currentChunk.length > 0) {
+            // Don't split in the middle of a JSON object/array
+            const balanced = isBalanced(currentChunk);
+            if (balanced) {
+                console.log('Creating new chunk due to size limit');
+                chunks.push(`${fileHeader}${currentChunk}`);
+                currentChunk = line;
+            } else {
+                currentChunk += '\n' + line;
+            }
+        } else {
+            currentChunk += (currentChunk ? "\n" : "") + line;
+        }
+    }
+    
+    if (currentChunk.length > 0) {
+        chunks.push(`${fileHeader}${currentChunk}`);
+    }
+    
+    console.log(`Config processing complete. Generated ${chunks.length} chunks`);
+    return chunks;
+  };
+  
+  /**
+   * Check if a JSON-like string has balanced braces and brackets
+   */
+  const isBalanced = (content: string): boolean => {
+    const stack = [];
+    let inString = false;
+    let escape = false;
+    
+    for (let i = 0; i < content.length; i++) {
+      const char = content[i];
+      
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      
+      if (char === '\\') {
+        escape = true;
+        continue;
+      }
+      
+      if (char === '"' && !inString) {
+        inString = true;
+      } else if (char === '"' && inString) {
+        inString = false;
+      } else if (!inString) {
+        if (char === '{' || char === '[') {
+          stack.push(char);
+        } else if (char === '}') {
+          if (stack.length === 0 || stack.pop() !== '{') {
+            return false;
+          }
+        } else if (char === ']') {
+          if (stack.length === 0 || stack.pop() !== '[') {
+            return false;
+          }
+        }
+      }
+    }
+    
+    return stack.length === 0;
+  };
+  
+  /**
+   * Default chunking by size while trying to preserve line boundaries
+   */
+  const splitBySize = (fileHeader: string, content: string): string[] => {
+    console.log('\nProcessing with default chunking...');
+    
+    if (content.length <= 1500) {
+        console.log('Content small enough for single chunk');
+        return [`${fileHeader}${content}`];
+    }
+    
+    const chunks: string[] = [];
+    let currentChunk = "";
+    const lines = content.split('\n');
+    
+    console.log(`Processing ${lines.length} lines`);
+    
+    for (const line of lines) {
+        if (currentChunk.length + line.length + 1 > 1500 && currentChunk.length > 0) {
+            console.log('Creating new chunk due to size limit');
+            chunks.push(`${fileHeader}${currentChunk}`);
+            currentChunk = line;
+        } else {
+            currentChunk += (currentChunk ? "\n" : "") + line;
+        }
+    }
+    
+    if (currentChunk.length > 0) {
+        chunks.push(`${fileHeader}${currentChunk}`);
+    }
+    
+    console.log(`Default chunking complete. Generated ${chunks.length} chunks`);
+    return chunks;
+  };


### PR DESCRIPTION
# Improve chunking script

## :recycle: Current situation & Problem
In this application we are ingesting entire Spezi module repositories which contain markdown documentation, code files, configuration files and others. The current chunking script is not optimized to properly chunk all these different types of files and results in chunks that are split in suboptimal ways.


## :gear: Release Notes 
Here we try a more sophisticated chunking strategy to handle the many different types of files present in the module repositories.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
